### PR TITLE
fix: typo

### DIFF
--- a/exercises/03.using-jsx/05.problem.fragments/README.mdx
+++ b/exercises/03.using-jsx/05.problem.fragments/README.mdx
@@ -37,5 +37,5 @@ that work.
 
 💯 As a little extra part of this, try to figure out why `<React.Fragment>` is
 needed at all. Might help if you look at what this looks like using
-`createElement` rather than JSX. As I said, understanding how JXS compiles
+`createElement` rather than JSX. As I said, understanding how JSX compiles
 to `createElement` really helps improve your capabilities with JSX!


### PR DESCRIPTION
`JXS` to `JSX`