### PR TITLE
Edit typo in README.mdx

### DIFF
--- a/exercises/02.raw-react/01.problem.elements/README.mdx
+++ b/exercises/02.raw-react/01.problem.elements/README.mdx
@@ -30,7 +30,7 @@ root.render(reactElement)
 
 <callout-info>
 
-    🦉 As a reminder, in a typical application, you're import will be something
+    🦉 As a reminder, in a typical application, your import will be something
     like
 
 ```ts nonumber nolang


### PR DESCRIPTION
Edit typo in line 33 from "you're" to "your".