### PR TITLE
Remove blockquote around code block

### DIFF
--- a/exercises/09.errors/02.problem.show-boundary/README.mdx
+++ b/exercises/09.errors/02.problem.show-boundary/README.mdx
@@ -7,9 +7,9 @@ We've got an error in our `onSubmit` handler like this. If you try to submit the
 form, you'll notice in the console that there's an error (someone made a typo
 😅). The error looks something like:
 
-> ```javascript
-> Uncaught TypeError: Cannot read properties of null (reading 'toUpperCase')
-> ```
+```javascript
+Uncaught TypeError: Cannot read properties of null (reading 'toUpperCase')
+```
 
 Before we fix the typo, we want to give the user better feedback for when
 something like this happens (right now, they don't know it's not working and


### PR DESCRIPTION
Having that code block in a blockquote makes its text italicized, bold and not aligned with the left edge of the content. If this was by design, please disregard this PR!