### PR TITLE
Align test spec for 07.04 with extra credit

### DIFF
--- a/exercises/07.forms/04.solution.submit/action.test.ts
+++ b/exercises/07.forms/04.solution.submit/action.test.ts
@@ -8,14 +8,6 @@ const form = await dtl.waitFor(() => {
 	return form
 })
 
-await testStep('Form has correct action', async () => {
-	expect(form).toHaveAttribute('action', 'api/onboarding')
-})
-
-await testStep('Form has correct method', async () => {
-	expect(form).toHaveAttribute('method', 'POST')
-})
-
-await testStep('Form has correct encType', async () => {
-	expect(form).toHaveAttribute('encType', 'multipart/form-data')
+await testStep('Form does not have incorrect method', async () => {
+	expect(form).not.toHaveAttribute('method', 'GET')
 })


### PR DESCRIPTION
As the spec is written, performing the extra credit will fail the tests. That's because the spec expects certain form attributes, while the extra credit says we can remove those attributes altogether.

One thing both of those conditions have in common (which the student must change if they want the test to pass) is the form must no longer GET from the endpoint.

While an argument for "progressive enhancement" _could_ be made here, I agree with Kent's comment in the accompanying video that this is a fully client-side app where passing the submission to the server doesn't really make sense.

Alternatively, the "extra credit" comment could be updated to say something like "FYI, the tests won't pass if you do this extra credit!"