### PR TITLE
Fix copywriting nitpicks (Modules 5-8)

### DIFF
--- a/exercises/05.typescript/06.problem.satisfies/README.mdx
+++ b/exercises/05.typescript/06.problem.satisfies/README.mdx
@@ -29,7 +29,7 @@ See? No type widening! Wahoo!
 
 <callout-info>
 	Before `satisfies` came out, we had to use a "Constrained Identity Function"
-	(pattern coined by your's truly). Learn more in **[How to write a Constrained
+	(pattern coined by yours truly). Learn more in **[How to write a Constrained
 	Identity Function (CIF) in
 	TypeScript](https://kentcdodds.com/blog/how-to-write-a-constrained-identity-function-in-typescript)**
 </callout-info>

--- a/exercises/05.typescript/README.mdx
+++ b/exercises/05.typescript/README.mdx
@@ -125,7 +125,7 @@ Don't worry if you struggle with TypeScript at first, the more you use it, the
 better you'll get at it, just like anything else.
 
 <callout-info>
-	Note: we're moving from the `*.html` files to `*.tsx` files. This is more
+	Note: We're moving from the `*.html` files to `*.tsx` files. This is more
 	real-world and also your editor likely supports TypeScript better within
 	TypeScript files rather than HTML files. From here on out, the `index.tsx`
 	file will be loaded onto the page automatically. We'll also get live reload of

--- a/exercises/06.styling/01.problem.style/index.tsx
+++ b/exercises/06.styling/01.problem.style/index.tsx
@@ -14,7 +14,7 @@ const smallBox = <div>small lightblue box</div>
 const mediumBox = <div>medium pink box</div>
 const largeBox = <div>large orange box</div>
 
-// 💰 the sizelssColorlessBox should still be a box, just with no size or color
+// 💰 the sizelessColorlessBox should still be a box, just with no size or color
 const sizelessColorlessBox = <div>sizeless colorless box</div>
 
 function App() {

--- a/exercises/06.styling/README.mdx
+++ b/exercises/06.styling/README.mdx
@@ -2,7 +2,7 @@
 
 <EpicVideo url="https://www.epicreact.dev/workshops/react-fundamentals/intro-to-styling" />
 
-There are two primary ways to style react components
+There are two primary ways to style React components
 
 1. Inline styles with the `style` prop
 2. Regular CSS with the `className` prop
@@ -70,7 +70,7 @@ some significant limitations (like lack of media queries and pseudo-selectors),
 so it's not always the best choice.
 
 <callout-warning class="aside">
-Note that in react the `{{` and `}}` is actually a combination of a JSX
+Note that in React the `{{` and `}}` is actually a combination of a JSX
 expression and an object expression. The same example above could be written
 like so:
 

--- a/exercises/08.inputs/01.problem.checkbox/index.tsx
+++ b/exercises/08.inputs/01.problem.checkbox/index.tsx
@@ -26,7 +26,7 @@ function App() {
 				<label htmlFor="colorInput">Favorite Color:</label>
 				<input id="colorInput" name="color" type="color" />
 			</div>
-			{/* 🐨 add a checkbox with the label "Waiver Signed" */}
+			{/* 🐨 add a checkbox named "waiver" with the label "Waiver Signed" */}
 			{/* 💰 put the <input> inside the <label> */}
 			<div>
 				<label htmlFor="startDateInput">Start Date:</label>

--- a/exercises/08.inputs/03.problem.radio/README.mdx
+++ b/exercises/08.inputs/03.problem.radio/README.mdx
@@ -8,10 +8,10 @@ that's the best option. Instead, let's use a radio group.
 
 📜 You can [learn about radio groups on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio)
 
-What's interesting about radio groups is that they are a group of inputs that
-share the same name. Only one of them can be selected at a time. Each radio
-input needs its own `label`. To label the entire group, you can use a
-`<fieldset>` and a `<legend>`.
+What's interesting about radio groups is that each radio group can contain
+multiple inputs that share the same name. Only one of them can be selected at
+a time. Each radio input needs its own `label`. To label the entire group, you
+can use a `<fieldset>` and a `<legend>`.
 
 Similar to checkboxes, to set the default value, you need to add the `checked`
 attribute to the input you want to be selected by default.

--- a/exercises/08.inputs/03.problem.radio/README.mdx
+++ b/exercises/08.inputs/03.problem.radio/README.mdx
@@ -13,8 +13,12 @@ multiple inputs that share the same name. Only one of them can be selected at
 a time. Each radio input needs its own `label`. To label the entire group, you
 can use a `<fieldset>` and a `<legend>`.
 
-Similar to checkboxes, to set the default value, you need to add the `checked`
-attribute to the input you want to be selected by default.
+<callout-info>
+	Note: Similar to checkboxes, to set the default value, you can set the
+	`checked` attribute to the input you want to be selected by default... but
+	in React, that will make your input read-only! We'll learn more about how
+	to set default values in React in a future lesson.
+</callout-info>
 
 Similar to a select `option`, you need to set the `value` on the input to
 determine what value will be sent to the server when the form is submitted.


### PR DESCRIPTION
Just like #386 here comes another PR to make the instructions a little clearer. Most of these edits are just little fiddly typo fixes, but I did a little bit of rephrasing and clarifying on the last 3 listed here.

* 1d595f1bc3eaf7e7dfc0325840d885d6ac1b2922: "Note: we're..." -> "Note: We're..."
* 7b1d195857a648ddd7accd5b95e2c62833e2684c: "Your's truly" -> "Yours truly"
* 0a07c9d5ab3f3dd735e6460e55468fded0c1317d: "react" -> "React"
* 9886d6b07ebb542779f04438f2a82db36afcec88: "sizelss" -> "sizeless"
* 4abd92874ddd00d5ce9e035b993b5da62ebedec6: Letting the student know the input name the integration test needs
* 9d0268e412726f434891fdb2a9c671c51916b3ce: This started as a typo fix, but then I reworded for clarity
* 5b5e53a9ffb5432731145fff1d4f8cad2b6df838: The checkbox lesson references `checked` but not its gotcha