### PR TITLE
docs: fix a couple of typos in 07.forms & 08.inputs

### DIFF
--- a/exercises/07.forms/04.problem.submit/index.tsx
+++ b/exercises/07.forms/04.problem.submit/index.tsx
@@ -8,7 +8,7 @@ function App() {
 			// 1️⃣ 🐨 set the method to "POST" then update api.server.ts to handle the POST request
 			// 2️⃣ 🐨 set the encType to "multipart/form-data"
 			// 3️⃣ 🐨 add an onSubmit handler that calls event.preventDefault()
-			// 4️⃣ 🐨 create a FormData object from the the form (💰 event.currentTarget)
+			// 4️⃣ 🐨 create a FormData object from the form (💰 event.currentTarget)
 			// 5️⃣ 🐨 log the result of Object.fromEntries(formData)
 			// 6️⃣ 💯 as extra credit, see what happens if you remove the action, method, and encType
 		>

--- a/exercises/08.inputs/05.problem.default-value/README.mdx
+++ b/exercises/08.inputs/05.problem.default-value/README.mdx
@@ -42,7 +42,7 @@ the first 10 characters:
 <input type="date" defaultValue={new Date().toISOString().slice(0, 10)} />
 ```
 
-This applies to `select` as well. Set it the the value of the option you want to
+This applies to `select` as well. Set it to the value of the option you want to
 have selected, and that one will be selected by default:
 
 ```tsx


### PR DESCRIPTION
`exercises/07.forms/04.problem.submit/index.tsx`
* Removed an additional/redundant `'the'` word.

`exercises/08.inputs/05.problem.default-value/README.mdx`
* Replaced `'the'` -> `'to'` as that seemed to be the intention with the sentence.