### PR TITLE
Stop testing wording of errors

### DIFF
--- a/exercises/09.errors/01.solution.composition/error-boundary.test.ts
+++ b/exercises/09.errors/01.solution.composition/error-boundary.test.ts
@@ -11,10 +11,6 @@ await testStep(
 		expect(errorMessage).toBeDefined()
 		expect(errorMessage.textContent).toContain('There was an error:')
 
-		// Check if the error message contains the specific error
-		const errorDetails = await screen.findByText(/invalid time/i)
-		expect(errorDetails).toBeDefined()
-
 		// Ensure the form is not rendered
 		const form = screen.queryByRole('form')
 		expect(form).toBeNull()

--- a/exercises/09.errors/02.solution.show-boundary/error-boundary.test.ts
+++ b/exercises/09.errors/02.solution.show-boundary/error-boundary.test.ts
@@ -15,10 +15,6 @@ await testStep('Error boundary is rendered after form submission', async () => {
 	expect(errorMessage).toBeDefined()
 	expect(errorMessage.textContent).toContain('There was an error:')
 
-	// Check if the error message contains the specific error
-	const errorDetails = await screen.findByText(/toUpperCase/i)
-	expect(errorDetails).toBeDefined()
-
 	// Ensure the form is not rendered after error
 	const form = screen.queryByRole('form')
 	expect(form).toBeNull()

--- a/exercises/09.errors/03.solution.reset/error-boundary.test.ts
+++ b/exercises/09.errors/03.solution.reset/error-boundary.test.ts
@@ -15,10 +15,6 @@ await testStep('Error boundary is rendered after form submission', async () => {
 	expect(errorMessage).toBeDefined()
 	expect(errorMessage.textContent).toContain('There was an error:')
 
-	// Check if the error message contains the specific error
-	const errorDetails = await screen.findByText(/toUpperCase/i)
-	expect(errorDetails).toBeDefined()
-
 	// Ensure the form is not rendered after error
 	const form = screen.queryByRole('form')
 	expect(form).toBeNull()


### PR DESCRIPTION
The wording of the errors varies greatly between e.g. Chrome and Firefox. Since tests were (presumably) written by someone using Chrome, users using Firefox wouldn't be able to get the tests to work. In this PR, tests are modified in such a way that they still fail on the initial playground version, and succeed when copying over the solution, for both browsers.

For completeness sake, here is how Firefox and Chrome word the error:

9.1 Chrome: `invalid time value`, Firefox: `invalid date`
9.2 Chrome: `Cannot read properties of null (reading 'toUpperCase')`, Firefox: `accountType is null`
9.3 same as 9.2

P.S. this is my very first contribution to an open source project ever :rocket: 