### PR TITLE
Improve error boundary instructions in comments

### DIFF
--- a/exercises/09.errors/01.problem.composition/index.tsx
+++ b/exercises/09.errors/01.problem.composition/index.tsx
@@ -98,6 +98,7 @@ function App() {
 
 // 🐨 create an ErrorFallback component here that accepts FallbackProps
 // and renders the error.message
+// The error message should be displayed in the format: "There was an error: [error message]"
 // 💯 you can make it look nice if you want
 // 📜 https://github.com/bvaughn/react-error-boundary#errorboundary-with-fallbackcomponent-prop
 


### PR DESCRIPTION
Clarify error message format in Error Boundaries exercise instructions to prevent test failures.