### PR TITLE
make test for { children } more flexible to allow whitespace

### DIFF
--- a/exercises/03.using-jsx/02.solution.interpolation/index.test.ts
+++ b/exercises/03.using-jsx/02.solution.interpolation/index.test.ts
@@ -20,5 +20,5 @@ await testStep('children is interpolated', async () => {
 		inlineScript.textContent,
 		'children should be interpolated',
 	).not.to.include('>Hello World<')
-	expect(inlineScript.textContent).to.include('{children}')
+	expect(inlineScript.textContent, 'expected script to include { children }').to.match(/{\s*children\s*}/)
 })


### PR DESCRIPTION
# Summary:

There's a unit test that searches the plain text of a script for the string literal `{children}`.  I was initially thrown because I had written `{ children }` with whitespace between the variable and the braces.  This is just a modification to the automated tests to allow for that flexible matching.