### PR TITLE
Update NodeJS version requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ speed on some of the tools and concepts we'll be covering:
 ## System Requirements
 
 - [git][git] v2.18 or greater
-- [NodeJS][node] v20 or greater
+- [NodeJS][node] v20, v22 or v24 (and no later)
 - [npm][npm] v8 or greater
 
 All of these must be available in your `PATH`. To verify things are set up


### PR DESCRIPTION
When running `npx epicshop start` the following error is shown:

...
`❌ Node.js version compatibility error
Current Node.js version: v26.4.0
Required Node.js versions: 20 || 22 || 24`
...

Hence my update to the README.